### PR TITLE
[SC-1-4] fix : forecast 모듈 UI 버그 수정 및 Preview 추가

### DIFF
--- a/common-ui/src/main/java/com/knichu/common_ui/enums/WeatherIcon.kt
+++ b/common-ui/src/main/java/com/knichu/common_ui/enums/WeatherIcon.kt
@@ -1,25 +1,29 @@
 package com.knichu.common_ui.enums
 
-enum class WeatherIcon(val value: String, val icon: Int) {
-    SUNNY("1", com.knichu.common_ui.R.drawable.ic_sunny_rounded),
-    CLOUDY_PARTLY("2", com.knichu.common_ui.R.drawable.ic_cloudy_partly),
-    CLOUDY_PARTLY_RAINY("3", com.knichu.common_ui.R.drawable.ic_cloudy_partly_rainy),
-    CLOUDY_PARTLY_SNOWING("4", com.knichu.common_ui.R.drawable.ic_cloudy_partly_snowing),
-    CLOUDY_PARTLY_WEATHER_MIX("5", com.knichu.common_ui.R.drawable.ic_cloudy_partly_weather_mix),
-    CLOUDY_PARTLY_RAINY_HEAVY("6", com.knichu.common_ui.R.drawable.ic_cloudy_partly_rainy_heavy),
-    CLOUDY("7", com.knichu.common_ui.R.drawable.ic_cloudy),
-    CLOUDY_RAINY("8", com.knichu.common_ui.R.drawable.ic_cloudy_rainy),
-    CLOUDY_SNOWING("9", com.knichu.common_ui.R.drawable.ic_cloudy_snowing),
-    CLOUDY_WEATHER_MIX("10", com.knichu.common_ui.R.drawable.ic_cloudy_weather_mix),
-    CLOUDY_RAINY_HEAVY("11", com.knichu.common_ui.R.drawable.ic_cloudy_rainy_heavy),
-    NIGHT_CLEAR("12", com.knichu.common_ui.R.drawable.ic_night_clear),
-    NIGHT_CLOUDY_PARTLY("13", com.knichu.common_ui.R.drawable.ic_night_cloudy_partly),
-    NIGHT_CLOUDY("14", com.knichu.common_ui.R.drawable.ic_night_cloudy),
-    NONE("", com.knichu.common_ui.R.drawable.ic_none);
+enum class WeatherIcon(val value: String, val icon: Int, val label: String) {
+    SUNNY("1", com.knichu.common_ui.R.drawable.ic_sunny_rounded, "맑음"),
+    CLOUDY_PARTLY("2", com.knichu.common_ui.R.drawable.ic_cloudy_partly, "구름 조금"),
+    CLOUDY_PARTLY_RAINY("3", com.knichu.common_ui.R.drawable.ic_cloudy_partly_rainy, "구름 조금 후 비"),
+    CLOUDY_PARTLY_SNOWING("4", com.knichu.common_ui.R.drawable.ic_cloudy_partly_snowing, "구름 조금 후 눈"),
+    CLOUDY_PARTLY_WEATHER_MIX("5", com.knichu.common_ui.R.drawable.ic_cloudy_partly_weather_mix, "구름 조금 후 비/눈"),
+    CLOUDY_PARTLY_RAINY_HEAVY("6", com.knichu.common_ui.R.drawable.ic_cloudy_partly_rainy_heavy, "구름 조금 후 폭우"),
+    CLOUDY("7", com.knichu.common_ui.R.drawable.ic_cloudy, "흐림"),
+    CLOUDY_RAINY("8", com.knichu.common_ui.R.drawable.ic_cloudy_rainy, "비"),
+    CLOUDY_SNOWING("9", com.knichu.common_ui.R.drawable.ic_cloudy_snowing, "눈"),
+    CLOUDY_WEATHER_MIX("10", com.knichu.common_ui.R.drawable.ic_cloudy_weather_mix, "비/눈"),
+    CLOUDY_RAINY_HEAVY("11", com.knichu.common_ui.R.drawable.ic_cloudy_rainy_heavy, "폭우"),
+    NIGHT_CLEAR("12", com.knichu.common_ui.R.drawable.ic_night_clear, "맑음"),
+    NIGHT_CLOUDY_PARTLY("13", com.knichu.common_ui.R.drawable.ic_night_cloudy_partly, "구름 조금"),
+    NIGHT_CLOUDY("14", com.knichu.common_ui.R.drawable.ic_night_cloudy, "흐림"),
+    NONE("", com.knichu.common_ui.R.drawable.ic_none, "-");
 
     companion object {
         fun getIconImage(value: String?): WeatherIcon {
             return values().firstOrNull { it.value == value } ?: NONE
+        }
+
+        fun getLabel(value: String?): String {
+            return values().firstOrNull { it.value == value }?.label ?: "-"
         }
     }
 }

--- a/forecast/src/main/java/com/knichu/forecast/ui/ForecastNavigation.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/ForecastNavigation.kt
@@ -1,6 +1,8 @@
 package com.knichu.forecast.ui
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
@@ -16,6 +18,15 @@ import com.knichu.forecast.ui.citysearch.CitySearchViewModel
 import com.knichu.forecast.ui.forecast.ForecastScreen
 import com.knichu.forecast.ui.forecast.ForecastUiEffect
 import com.knichu.forecast.ui.forecast.ForecastViewModel
+
+private fun Context.findActivity(): Activity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
 
 sealed class ForecastRoute(val route: String) {
     object Forecast   : ForecastRoute("forecast")
@@ -40,7 +51,7 @@ fun ForecastNavHost(
                 is ForecastUiEffect.NavigateToCityManage ->
                     navController.navigate(ForecastRoute.CityManage.route)
                 is ForecastUiEffect.ExitApp ->
-                    (context as? Activity)?.finish()
+                    context.findActivity()?.finish()
             }
         }
     }

--- a/forecast/src/main/java/com/knichu/forecast/ui/citymanage/CityManageScreen.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/citymanage/CityManageScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,7 +20,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -36,17 +36,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+// ── Stateful (ViewModel 연결) ──
 @Composable
 fun CityManageScreen(
     viewModel: CityManageViewModel,
     onNavigateBack: () -> Unit
 ) {
     val state by viewModel.uiState.collectAsState()
-    var showDeleteDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.uiEffect.collect { effect ->
@@ -56,6 +56,31 @@ fun CityManageScreen(
         }
     }
 
+    CityManageScreen(
+        cityList = state.cityList,
+        isInSelectionMode = state.isInSelectionMode,
+        selectedCitySet = state.selectedCitySet,
+        onToggleSelectionMode = { viewModel.handleIntent(CityManageUiIntent.ToggleSelectionMode) },
+        onToggleCitySelection = { viewModel.handleIntent(CityManageUiIntent.ToggleCitySelection(it)) },
+        onDeleteSelected = { viewModel.handleIntent(CityManageUiIntent.DeleteSelectedCities) },
+        onNavigateBack = { viewModel.handleIntent(CityManageUiIntent.NavigateBack) }
+    )
+}
+
+// ── Stateless (Preview 가능) ──
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun CityManageScreen(
+    cityList: List<String>,
+    isInSelectionMode: Boolean,
+    selectedCitySet: Set<String>,
+    onToggleSelectionMode: () -> Unit,
+    onToggleCitySelection: (String) -> Unit,
+    onDeleteSelected: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
@@ -63,7 +88,7 @@ fun CityManageScreen(
             text = { Text("선택한 도시들을 삭제하시겠습니까?") },
             confirmButton = {
                 TextButton(onClick = {
-                    viewModel.handleIntent(CityManageUiIntent.DeleteSelectedCities)
+                    onDeleteSelected()
                     showDeleteDialog = false
                 }) { Text("확인") }
             },
@@ -78,28 +103,25 @@ fun CityManageScreen(
             TopAppBar(
                 title = { Text("도시 관리", fontWeight = FontWeight.Bold) },
                 navigationIcon = {
-                    IconButton(onClick = { viewModel.handleIntent(CityManageUiIntent.NavigateBack) }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "뒤로"
-                        )
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "뒤로")
                     }
                 },
                 actions = {
-                    TextButton(onClick = { viewModel.handleIntent(CityManageUiIntent.ToggleSelectionMode) }) {
-                        Text(if (state.isInSelectionMode) "취소" else "선택")
+                    TextButton(onClick = onToggleSelectionMode) {
+                        Text(if (isInSelectionMode) "취소" else "선택")
                     }
                 }
             )
         },
         bottomBar = {
-            AnimatedVisibility(visible = state.isInSelectionMode && state.selectedCitySet.isNotEmpty()) {
+            AnimatedVisibility(visible = isInSelectionMode && selectedCitySet.isNotEmpty()) {
                 Button(
                     onClick = { showDeleteDialog = true },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
-                ) { Text("삭제 (${state.selectedCitySet.size})") }
+                ) { Text("삭제 (${selectedCitySet.size})") }
             }
         }
     ) { paddingValues ->
@@ -108,7 +130,7 @@ fun CityManageScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            if (state.cityList.isEmpty()) {
+            if (cityList.isEmpty()) {
                 Text(
                     text = "저장된 도시가 없습니다",
                     modifier = Modifier.align(Alignment.Center),
@@ -116,20 +138,16 @@ fun CityManageScreen(
                 )
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    items(state.cityList) { city ->
+                    items(cityList) { city ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .combinedClickable(
                                     onClick = {
-                                        if (state.isInSelectionMode) {
-                                            viewModel.handleIntent(CityManageUiIntent.ToggleCitySelection(city))
-                                        }
+                                        if (isInSelectionMode) onToggleCitySelection(city)
                                     },
                                     onLongClick = {
-                                        if (!state.isInSelectionMode) {
-                                            viewModel.handleIntent(CityManageUiIntent.ToggleSelectionMode)
-                                        }
+                                        if (!isInSelectionMode) onToggleSelectionMode()
                                     }
                                 )
                                 .padding(horizontal = 16.dp, vertical = 12.dp),
@@ -137,12 +155,10 @@ fun CityManageScreen(
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {
                             Text(city, fontSize = 16.sp)
-                            AnimatedVisibility(visible = state.isInSelectionMode) {
+                            AnimatedVisibility(visible = isInSelectionMode) {
                                 Checkbox(
-                                    checked = city in state.selectedCitySet,
-                                    onCheckedChange = {
-                                        viewModel.handleIntent(CityManageUiIntent.ToggleCitySelection(city))
-                                    }
+                                    checked = city in selectedCitySet,
+                                    onCheckedChange = { onToggleCitySelection(city) }
                                 )
                             }
                         }
@@ -150,6 +166,62 @@ fun CityManageScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+// ────────────── Previews ──────────────
+
+@Preview(showBackground = true, name = "도시 관리 - 일반")
+@Composable
+private fun CityManageScreenPreview() {
+    MaterialTheme {
+        Surface {
+            CityManageScreen(
+                cityList = listOf("서울", "부산", "제주", "대구", "인천"),
+                isInSelectionMode = false,
+                selectedCitySet = emptySet(),
+                onToggleSelectionMode = {},
+                onToggleCitySelection = {},
+                onDeleteSelected = {},
+                onNavigateBack = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "도시 관리 - 선택 모드")
+@Composable
+private fun CityManageScreenSelectionPreview() {
+    MaterialTheme {
+        Surface {
+            CityManageScreen(
+                cityList = listOf("서울", "부산", "제주", "대구", "인천"),
+                isInSelectionMode = true,
+                selectedCitySet = setOf("부산", "제주"),
+                onToggleSelectionMode = {},
+                onToggleCitySelection = {},
+                onDeleteSelected = {},
+                onNavigateBack = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "도시 관리 - 비어있음")
+@Composable
+private fun CityManageScreenEmptyPreview() {
+    MaterialTheme {
+        Surface {
+            CityManageScreen(
+                cityList = emptyList(),
+                isInSelectionMode = false,
+                selectedCitySet = emptySet(),
+                onToggleSelectionMode = {},
+                onToggleCitySelection = {},
+                onDeleteSelected = {},
+                onNavigateBack = {}
+            )
         }
     }
 }

--- a/forecast/src/main/java/com/knichu/forecast/ui/citysearch/CitySearchScreen.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/citysearch/CitySearchScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -32,11 +34,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.knichu.domain.vo.CityLocationItemVO
 
-@OptIn(ExperimentalMaterial3Api::class)
+// ── Stateful (ViewModel 연결) ──
 @Composable
 fun CitySearchScreen(
     viewModel: CitySearchViewModel,
@@ -44,19 +47,39 @@ fun CitySearchScreen(
 ) {
     val state by viewModel.uiState.collectAsState()
     val context = LocalContext.current
-    var showAddDialog by remember { mutableStateOf<CityLocationItemVO?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.uiEffect.collect { effect ->
             when (effect) {
-                is CitySearchUiEffect.NavigateBack      -> onNavigateBack()
-                is CitySearchUiEffect.ShowToast         ->
+                is CitySearchUiEffect.NavigateBack ->
+                    onNavigateBack()
+                is CitySearchUiEffect.ShowToast ->
                     Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
             }
         }
     }
 
-    // 도시 추가 확인 다이얼로그
+    CitySearchScreen(
+        searchQuery = state.searchQuery,
+        searchedCityList = state.searchedCityList,
+        onSearchQueryChange = { viewModel.handleIntent(CitySearchUiIntent.Search(it)) },
+        onAddCity = { viewModel.handleIntent(CitySearchUiIntent.AddCity(it)) },
+        onNavigateBack = { viewModel.handleIntent(CitySearchUiIntent.NavigateBack) }
+    )
+}
+
+// ── Stateless (Preview 가능) ──
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CitySearchScreen(
+    searchQuery: String,
+    searchedCityList: List<CityLocationItemVO>,
+    onSearchQueryChange: (String) -> Unit,
+    onAddCity: (String) -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    var showAddDialog by remember { mutableStateOf<CityLocationItemVO?>(null) }
+
     showAddDialog?.let { item ->
         AlertDialog(
             onDismissRequest = { showAddDialog = null },
@@ -64,7 +87,7 @@ fun CitySearchScreen(
             text = { Text("이 도시를 추가하시겠습니까?") },
             confirmButton = {
                 TextButton(onClick = {
-                    item.cityName?.let { viewModel.handleIntent(CitySearchUiIntent.AddCity(it)) }
+                    item.cityName?.let { onAddCity(it) }
                     showAddDialog = null
                 }) { Text("확인") }
             },
@@ -79,11 +102,8 @@ fun CitySearchScreen(
             TopAppBar(
                 title = { Text("도시 검색", fontWeight = FontWeight.Bold) },
                 navigationIcon = {
-                    IconButton(onClick = { viewModel.handleIntent(CitySearchUiIntent.NavigateBack) }) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = "뒤로"
-                        )
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(imageVector = Icons.Filled.ArrowBack, contentDescription = "뒤로")
                     }
                 }
             )
@@ -95,8 +115,8 @@ fun CitySearchScreen(
                 .padding(paddingValues)
         ) {
             OutlinedTextField(
-                value = state.searchQuery,
-                onValueChange = { viewModel.handleIntent(CitySearchUiIntent.Search(it)) },
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp),
@@ -105,7 +125,7 @@ fun CitySearchScreen(
             )
 
             Box(modifier = Modifier.fillMaxSize()) {
-                if (state.searchedCityList.isEmpty() && state.searchQuery.isNotEmpty()) {
+                if (searchedCityList.isEmpty() && searchQuery.isNotEmpty()) {
                     Text(
                         text = "검색 결과가 없습니다",
                         modifier = Modifier.align(Alignment.Center),
@@ -113,7 +133,7 @@ fun CitySearchScreen(
                     )
                 } else {
                     LazyColumn(modifier = Modifier.fillMaxSize()) {
-                        items(state.searchedCityList) { item ->
+                        items(searchedCityList) { item ->
                             Text(
                                 text = item.cityName ?: "-",
                                 modifier = Modifier
@@ -127,6 +147,60 @@ fun CitySearchScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+// ────────────── Previews ──────────────
+
+@Preview(showBackground = true, name = "도시 검색 - 초기")
+@Composable
+private fun CitySearchScreenEmptyPreview() {
+    MaterialTheme {
+        Surface {
+            CitySearchScreen(
+                searchQuery = "",
+                searchedCityList = emptyList(),
+                onSearchQueryChange = {},
+                onAddCity = {},
+                onNavigateBack = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "도시 검색 - 결과 있음")
+@Composable
+private fun CitySearchScreenWithResultsPreview() {
+    MaterialTheme {
+        Surface {
+            CitySearchScreen(
+                searchQuery = "서울",
+                searchedCityList = listOf(
+                    CityLocationItemVO(cityName = "서울특별시"),
+                    CityLocationItemVO(cityName = "서울 강남구"),
+                    CityLocationItemVO(cityName = "서울 마포구"),
+                ),
+                onSearchQueryChange = {},
+                onAddCity = {},
+                onNavigateBack = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "도시 검색 - 결과 없음")
+@Composable
+private fun CitySearchScreenNoResultsPreview() {
+    MaterialTheme {
+        Surface {
+            CitySearchScreen(
+                searchQuery = "xyz",
+                searchedCityList = emptyList(),
+                onSearchQueryChange = {},
+                onAddCity = {},
+                onNavigateBack = {}
+            )
         }
     }
 }

--- a/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastScreen.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastScreen.kt
@@ -1,6 +1,5 @@
 package com.knichu.forecast.ui.forecast
 
-import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -46,12 +45,19 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.material3.MaterialTheme
+import com.knichu.common_ui.enums.WeatherIcon
+import com.knichu.domain.vo.AirPollutionDataVO
+import com.knichu.domain.vo.SunriseSunsetVO
 import com.knichu.domain.vo.Weather24HourItemVO
+import com.knichu.domain.vo.WeatherForecastTextVO
 import com.knichu.domain.vo.WeatherNowCityListItemVO
+import com.knichu.domain.vo.WeatherNowVO
+import com.knichu.domain.vo.WeatherOtherInfoVO
 import com.knichu.domain.vo.WeatherWeeklyItemVO
 import kotlinx.coroutines.launch
 
@@ -66,7 +72,6 @@ fun ForecastScreen(
     )
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
-    val context = LocalContext.current
     var showExitDialog by remember { mutableStateOf(false) }
     var showCitySelectDialog by remember { mutableStateOf<WeatherNowCityListItemVO?>(null) }
     var showCurrentPositionDialog by remember { mutableStateOf(false) }
@@ -102,7 +107,7 @@ fun ForecastScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showExitDialog = false
-                    (context as? Activity)?.finish()
+                    viewModel.handleIntent(ForecastUiIntent.ExitApp)
                 }) { Text("확인") }
             },
             dismissButton = {
@@ -255,7 +260,7 @@ private fun ForecastDrawerContent(
                 ) {
                     Text(item.city ?: "-", fontSize = 16.sp)
                     Spacer(modifier = Modifier.weight(1f))
-                    Text("${item.temperature}° ${item.weatherCondition ?: ""}", fontSize = 14.sp)
+                    Text("${item.temperature}° ${WeatherIcon.getLabel(item.weatherCondition)}", fontSize = 14.sp)
                 }
                 Divider()
             }
@@ -294,7 +299,7 @@ private fun ForecastContent(
                 WeatherNowSection(
                     temperature = now.temperature,
                     city = now.city,
-                    condition = now.weatherCondition
+                    condition = WeatherIcon.getLabel(now.weatherCondition)
                 )
             }
         }
@@ -384,7 +389,7 @@ private fun Weather24HourSection(items: List<Weather24HourItemVO>) {
             items(items) { item ->
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(item.time ?: "-", fontSize = 12.sp)
-                    Text(item.weatherCondition ?: "-", fontSize = 11.sp)
+                    Text(WeatherIcon.getLabel(item.weatherCondition), fontSize = 11.sp)
                     Text("${item.temperature ?: "-"}°", fontWeight = FontWeight.Bold)
                     Text("${item.rainProbability ?: "0"}%", fontSize = 11.sp)
                 }
@@ -405,7 +410,7 @@ private fun WeatherWeeklySection(items: List<WeatherWeeklyItemVO>) {
                 ) {
                     Text(item.dayOfTheWeek ?: "-", modifier = Modifier.width(36.dp))
                     Text("${item.rainProbability ?: "0"}%", fontSize = 12.sp)
-                    Text("${item.weatherConditionAM ?: "-"} / ${item.weatherConditionPM ?: "-"}", fontSize = 12.sp)
+                    Text("${WeatherIcon.getLabel(item.weatherConditionAM)} / ${WeatherIcon.getLabel(item.weatherConditionPM)}", fontSize = 12.sp)
                     Text("${item.minTemperature ?: "-"}° / ${item.maxTemperature ?: "-"}°")
                 }
             }
@@ -421,5 +426,66 @@ private fun InfoCard(title: String, content: @Composable () -> Unit) {
             Spacer(modifier = Modifier.height(8.dp))
             content()
         }
+    }
+}
+
+// ────────────── Previews ──────────────
+
+private val previewState = ForecastUiState(
+    weatherNow = WeatherNowVO(city = "서울", temperature = "23", weatherCondition = "맑음"),
+    weather24Hour = listOf(
+        Weather24HourItemVO(time = "1400", weatherCondition = "맑음", temperature = "23", rainProbability = "10"),
+        Weather24HourItemVO(time = "1700", weatherCondition = "구름많음", temperature = "21", rainProbability = "20"),
+        Weather24HourItemVO(time = "2000", weatherCondition = "흐림", temperature = "18", rainProbability = "40"),
+        Weather24HourItemVO(time = "2300", weatherCondition = "비", temperature = "16", rainProbability = "70"),
+    ),
+    weatherWeekly = listOf(
+        WeatherWeeklyItemVO(dayOfTheWeek = "월", rainProbability = "10", weatherConditionAM = "맑음", weatherConditionPM = "맑음", minTemperature = "15", maxTemperature = "25"),
+        WeatherWeeklyItemVO(dayOfTheWeek = "화", rainProbability = "30", weatherConditionAM = "구름", weatherConditionPM = "비", minTemperature = "14", maxTemperature = "22"),
+        WeatherWeeklyItemVO(dayOfTheWeek = "수", rainProbability = "60", weatherConditionAM = "비", weatherConditionPM = "흐림", minTemperature = "13", maxTemperature = "19"),
+    ),
+    sunriseSunset = SunriseSunsetVO(sunriseTime = "0532", sunsetTime = "1948"),
+    weatherOtherInfo = WeatherOtherInfoVO(humidity = "55", windDirection = "북서", windSpeed = "3.2"),
+    weatherForecastText = WeatherForecastTextVO(weatherForecastString = "오늘은 전국적으로 맑은 날씨가 예상됩니다. 낮 최고기온은 25도 내외입니다."),
+    airPollution = AirPollutionDataVO(pm2_5Density = "12", pm10Density = "24", pm2_5Quality = "좋음", pm10Quality = "보통"),
+    storedCityList = listOf(
+        WeatherNowCityListItemVO(city = "부산", temperature = "25", weatherCondition = "맑음"),
+        WeatherNowCityListItemVO(city = "제주", temperature = "27", weatherCondition = "구름많음"),
+    ),
+    currentPositionCity = WeatherNowVO(city = "서울", temperature = "23", weatherCondition = "맑음")
+)
+
+@Preview(showBackground = true, name = "날씨 메인 콘텐츠")
+@Composable
+private fun ForecastContentPreview() {
+    MaterialTheme {
+        ForecastContent(
+            state = previewState,
+            listState = rememberLazyListState()
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "날씨 메인 콘텐츠 - 로딩")
+@Composable
+private fun ForecastContentLoadingPreview() {
+    MaterialTheme {
+        Box(modifier = Modifier.fillMaxSize()) {
+            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 320, name = "드로어 - 도시 목록")
+@Composable
+private fun ForecastDrawerPreview() {
+    MaterialTheme {
+        ForecastDrawerContent(
+            state = previewState,
+            onCityClick = {},
+            onCurrentPositionClick = {},
+            onAddCityClick = {},
+            onManageCityClick = {}
+        )
     }
 }


### PR DESCRIPTION
## 🔴 작업 내역
- forecast 모듈 Compose Preview 추가 (ForecastScreen, CityManageScreen, CitySearchScreen)
- CityManageScreen, CitySearchScreen Stateful/Stateless 패턴으로 리팩토링
- weatherCondition 숫자 코드 한국어 텍스트로 변환 (WeatherIcon enum label 필드 추가)
- 앱 종료 다이얼로그 확인 버튼 미동작 수정 (ContextThemeWrapper 언래핑 처리)

## 🟡 추가한 라이브러리
- x

## 🟢 기타 전달 사항
- x