### PR TITLE
[SC-1-8] feat : nationwide 탭 전국 날씨 지도 구현 (Naver Maps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,4 +336,7 @@ obj/
 
 !/gradle/wrapper/gradle-wrapper.jar
 
+# Claude Code
+CLAUDE.md
+
 # End of https://www.toptal.com/developers/gitignore/api/intellij,android,androidstudio,kotlin,macos

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,8 @@ android {
         versionName = DefaultConfig.VERSION_NAME
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders["naverMapsClientId"] = getPropertyValue("naverMapsClientId")
+        buildConfigField("String", "NAVER_MAPS_CLIENT_ID", "\"${getPropertyValue("naverMapsClientId")}\"")
 
 //        // @InstallIn 무시 코드
 //        javaCompileOptions {
@@ -96,6 +98,10 @@ android {
         }
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -116,6 +122,9 @@ dependencies {
     api(project(":nationwide"))
     api(project(":setting"))
     api(project(":data"))
+
+    // Naver Maps (Application 클래스에서 SDK 초기화용)
+    implementation("com.naver.maps:map-sdk:3.23.2")
 
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.appcompat:appcompat:1.6.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Suncloud"
         tools:targetApi="33">
+        <meta-data
+            android:name="com.naver.maps.map.NCP_KEY_ID"
+            android:value="${naverMapsClientId}" />
+
         <activity
             android:name="com.knichu.gateway.ui.GatewayActivity"
             android:exported="true"

--- a/app/src/main/java/com/knichu/suncloud/MainApplication.kt
+++ b/app/src/main/java/com/knichu/suncloud/MainApplication.kt
@@ -1,9 +1,14 @@
 package com.knichu.suncloud
 
 import android.app.Application
+import com.naver.maps.map.NaverMapSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class MainApplication : Application() {
 
+    override fun onCreate() {
+        super.onCreate()
+        NaverMapSdk.getInstance(this).client = NaverMapSdk.NcpKeyClient(BuildConfig.NAVER_MAPS_CLIENT_ID)
+    }
 }

--- a/nationwide/build.gradle.kts
+++ b/nationwide/build.gradle.kts
@@ -67,6 +67,9 @@ dependencies {
     api(project(":common"))
     api(project(":common-ui"))
 
+    // Naver Maps
+    implementation("com.naver.maps:map-sdk:3.23.2")
+
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.9.0")

--- a/nationwide/src/main/java/com/knichu/nationwide/model/CityData.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/model/CityData.kt
@@ -1,0 +1,23 @@
+package com.knichu.nationwide.model
+
+data class CityInfo(
+    val name: String,
+    val lat: Double,
+    val lon: Double,
+    val tier: Int
+)
+
+// 지도에 표시할 도시와 티어 정의 — 좌표는 cityCode.json에서 런타임에 로드
+val CITY_TIER_MAP: Map<String, Int> = mapOf(
+    // Tier 1 — 광역시 및 특별시 (전국 뷰에서 표시)
+    "서울" to 1, "부산" to 1, "대구" to 1, "인천" to 1,
+    "광주" to 1, "대전" to 1, "울산" to 1, "세종" to 1, "제주" to 1,
+
+    // Tier 2 — 주요 시 (확대 시 추가 표시)
+    "수원" to 2, "고양" to 2, "창원" to 2, "청주" to 2,
+    "전주" to 2, "천안" to 2, "춘천" to 2, "강릉" to 2,
+    "포항" to 2, "여수" to 2, "목포" to 2, "안동" to 2,
+    "구미" to 2, "경주" to 2, "속초" to 2, "서귀포" to 2,
+)
+
+const val ZOOM_TIER1_ONLY = 7.0

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/MarkerBitmapFactory.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/MarkerBitmapFactory.kt
@@ -1,0 +1,86 @@
+package com.knichu.nationwide.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BlurMaskFilter
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.util.TypedValue
+import androidx.appcompat.content.res.AppCompatResources
+import com.knichu.common_ui.enums.WeatherIcon
+import com.naver.maps.map.overlay.OverlayImage
+
+object MarkerBitmapFactory {
+
+    fun create(context: Context, weatherCondition: String?, temperature: String?): OverlayImage =
+        OverlayImage.fromBitmap(createBitmap(context, weatherCondition, temperature))
+
+    private fun createBitmap(context: Context, weatherCondition: String?, temperature: String?): Bitmap {
+        val dm = context.resources.displayMetrics
+        fun dp(v: Float) = (v * dm.density).toInt()
+        fun sp(v: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, v, dm)
+
+        val iconSize = dp(26f)
+        val hPad = dp(8f)
+        val vPad = dp(6f)
+        val gap = dp(4f)
+        val shadowRadius = dp(3f).toFloat()
+        val shadowInset = dp(2f)
+
+        val tempText = if (temperature != null) "${temperature}°" else "-"
+
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = sp(12f)
+            typeface = Typeface.DEFAULT_BOLD
+            color = Color.parseColor("#333333")
+        }
+
+        val textWidth = textPaint.measureText(tempText).toInt()
+        val textHeight = (textPaint.descent() - textPaint.ascent()).toInt()
+        val contentH = maxOf(iconSize, textHeight)
+        val bitmapW = hPad + iconSize + gap + textWidth + hPad + shadowInset
+        val bitmapH = vPad * 2 + contentH + shadowInset
+
+        val bitmap = Bitmap.createBitmap(bitmapW, bitmapH, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        val r = (bitmapH - shadowInset) / 2f
+        val bgRect = RectF(
+            shadowInset.toFloat(),
+            shadowInset.toFloat(),
+            (bitmapW - shadowInset).toFloat(),
+            (bitmapH - shadowInset).toFloat()
+        )
+
+        // 그림자
+        val shadowPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.parseColor("#33000000")
+            maskFilter = BlurMaskFilter(shadowRadius, BlurMaskFilter.Blur.NORMAL)
+        }
+        canvas.drawRoundRect(bgRect, r, r, shadowPaint)
+
+        // 흰색 배경
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+        canvas.drawRoundRect(bgRect, r, r, bgPaint)
+
+        // 날씨 아이콘
+        val iconTop = shadowInset + (bitmapH - shadowInset - iconSize) / 2
+        val iconLeft = hPad + shadowInset
+        AppCompatResources.getDrawable(context, WeatherIcon.getIconImage(weatherCondition).icon)
+            ?.apply {
+                setBounds(iconLeft, iconTop, iconLeft + iconSize, iconTop + iconSize)
+                draw(canvas)
+            }
+
+        // 기온 텍스트
+        val textX = (iconLeft + iconSize + gap).toFloat()
+        val centerY = shadowInset + (bitmapH - shadowInset) / 2f
+        val textY = centerY - (textPaint.ascent() + textPaint.descent()) / 2f
+        canvas.drawText(tempText, textX, textY, textPaint)
+
+        return bitmap
+    }
+}

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideContract.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideContract.kt
@@ -1,9 +1,22 @@
 package com.knichu.nationwide.ui
 
+import com.knichu.nationwide.model.CityInfo
+
 data class NationwideUiState(
-    val dummy: Unit = Unit
+    val allCities: List<CityInfo> = emptyList(),
+    val cityWeatherMap: Map<String, CityWeatherState> = emptyMap(),
+    val error: String? = null
 )
 
-sealed class NationwideUiIntent
+data class CityWeatherState(
+    val temperature: String? = null,
+    val weatherCondition: String? = null,
+    val isLoading: Boolean = false
+)
+
+sealed class NationwideUiIntent {
+    object LoadInitialData : NationwideUiIntent()
+    data class OnCameraIdle(val zoom: Double) : NationwideUiIntent()
+}
 
 sealed class NationwideUiEffect

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideHostFragment.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideHostFragment.kt
@@ -23,7 +23,7 @@ class NationwideHostFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 MaterialTheme {
-                    NationwideScreen()
+                    NationwideScreen(viewModel = viewModel)
                 }
             }
         }

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideScreen.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideScreen.kt
@@ -1,29 +1,151 @@
 package com.knichu.nationwide.ui
 
-import androidx.compose.foundation.layout.Box
+import android.content.Context
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
+import com.naver.maps.map.CameraPosition
+import com.naver.maps.map.MapView
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.overlay.Marker
+import com.knichu.nationwide.model.CityInfo
+import com.knichu.nationwide.model.ZOOM_TIER1_ONLY
+
+private const val KOREA_CENTER_LAT = 36.5
+private const val KOREA_CENTER_LON = 127.8
+private const val INITIAL_ZOOM = 6.3
 
 @Composable
-fun NationwideScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(text = "출시 준비중입니다", fontSize = 34.sp)
+fun NationwideScreen(viewModel: NationwideViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    NationwideMapView(
+        uiState = uiState,
+        onInitialLoad = { viewModel.handleIntent(NationwideUiIntent.LoadInitialData) },
+        onCameraIdle = { zoom -> viewModel.handleIntent(NationwideUiIntent.OnCameraIdle(zoom)) },
+        modifier = Modifier.fillMaxSize()
+    )
+}
+
+@Composable
+private fun NationwideMapView(
+    uiState: NationwideUiState,
+    onInitialLoad: () -> Unit,
+    onCameraIdle: (Double) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val naverMapRef = remember { mutableStateOf<NaverMap?>(null) }
+    val markersRef = remember { mutableMapOf<String, Marker>() }
+    val currentZoom = remember { mutableStateOf(INITIAL_ZOOM) }
+
+    AndroidView(
+        factory = { ctx ->
+            MapView(ctx).apply {
+                lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+                    override fun onCreate(owner: LifecycleOwner) = this@apply.onCreate(null)
+                    override fun onStart(owner: LifecycleOwner) = this@apply.onStart()
+                    override fun onResume(owner: LifecycleOwner) = this@apply.onResume()
+                    override fun onPause(owner: LifecycleOwner) = this@apply.onPause()
+                    override fun onStop(owner: LifecycleOwner) = this@apply.onStop()
+                    override fun onDestroy(owner: LifecycleOwner) = this@apply.onDestroy()
+                })
+
+                getMapAsync { map ->
+                    naverMapRef.value = map
+                    setupInitialCamera(map)
+                    map.addOnCameraIdleListener {
+                        currentZoom.value = map.cameraPosition.zoom
+                        onCameraIdle(map.cameraPosition.zoom)
+                    }
+                    onInitialLoad()
+                }
+            }
+        },
+        modifier = modifier
+    )
+
+    // zoom 변화 또는 날씨 데이터 변화 시 마커 업데이트
+    val map = naverMapRef.value
+    LaunchedEffect(map, uiState.cityWeatherMap, uiState.allCities, currentZoom.value) {
+        if (map == null) return@LaunchedEffect
+        updateMarkers(context, map, uiState, markersRef)
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-private fun NationwideScreenPreview() {
-    MaterialTheme {
-        NationwideScreen()
+private val KOREA_BOUNDS = LatLngBounds(
+    LatLng(33.0, 124.5),  // 남서 (제주 남단 / 서해)
+    LatLng(38.9, 132.0)   // 북동 (휴전선 근처 / 독도)
+)
+private const val MIN_ZOOM = 5.5
+
+private fun setupInitialCamera(map: NaverMap) {
+    map.extent = KOREA_BOUNDS
+    map.minZoom = MIN_ZOOM
+    map.cameraPosition = CameraPosition(LatLng(KOREA_CENTER_LAT, KOREA_CENTER_LON), INITIAL_ZOOM)
+    with(map.uiSettings) {
+        isZoomControlEnabled = false
+        isCompassEnabled = false
+        isScaleBarEnabled = false
+    }
+}
+
+private fun updateMarkers(
+    context: Context,
+    map: NaverMap,
+    uiState: NationwideUiState,
+    markers: MutableMap<String, Marker>
+) {
+    val zoom = map.cameraPosition.zoom
+    val maxTier = if (zoom <= ZOOM_TIER1_ONLY) 1 else 2
+    val visibleCityNames = uiState.allCities
+        .filter { it.tier <= maxTier }
+        .map { it.name }
+        .toSet()
+
+    // 범위 밖 마커 제거
+    val iter = markers.iterator()
+    while (iter.hasNext()) {
+        val entry = iter.next()
+        if (entry.key !in visibleCityNames) {
+            entry.value.map = null
+            iter.remove()
+        }
+    }
+
+    // 날씨 데이터가 준비된 도시 마커 추가/업데이트
+    uiState.cityWeatherMap.forEach { (cityName, weather) ->
+        if (cityName !in visibleCityNames) return@forEach
+        if (weather.isLoading || weather.temperature == null) return@forEach
+
+        val cityInfo = uiState.allCities.find { it.name == cityName } ?: return@forEach
+        val icon = MarkerBitmapFactory.create(context, weather.weatherCondition, weather.temperature)
+
+        val existing = markers[cityName]
+        if (existing != null) {
+            existing.icon = icon
+            existing.captionText = cityName
+        } else {
+            markers[cityName] = Marker().apply {
+                position = LatLng(cityInfo.lat, cityInfo.lon)
+                this.icon = icon
+                captionText = cityName
+                captionTextSize = 12f
+                this.map = map
+            }
+        }
     }
 }

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideViewModel.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideViewModel.kt
@@ -1,20 +1,104 @@
 package com.knichu.nationwide.ui
 
+import android.content.Context
+import androidx.lifecycle.viewModelScope
 import com.knichu.common.base.BaseMviViewModel
-import com.knichu.domain.useCase.AirPollutionUseCase
-import com.knichu.domain.useCase.DataStoreUseCase
 import com.knichu.domain.useCase.WeatherUseCase
+import com.knichu.nationwide.model.CITY_TIER_MAP
+import com.knichu.nationwide.model.CityInfo
+import com.knichu.nationwide.model.ZOOM_TIER1_ONLY
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
 import javax.inject.Inject
 
 @HiltViewModel
 class NationwideViewModel @Inject constructor(
-    private val airPollutionUseCase: AirPollutionUseCase,
-    private val weatherUseCase: WeatherUseCase,
-    private val dataStoreUseCase: DataStoreUseCase
+    @ApplicationContext private val context: Context,
+    private val weatherUseCase: WeatherUseCase
 ) : BaseMviViewModel<NationwideUiIntent, NationwideUiState, NationwideUiEffect>() {
 
     override fun initialState() = NationwideUiState()
 
-    override fun handleIntent(intent: NationwideUiIntent) {}
+    override fun handleIntent(intent: NationwideUiIntent) {
+        when (intent) {
+            is NationwideUiIntent.LoadInitialData -> loadInitialData()
+            is NationwideUiIntent.OnCameraIdle -> onCameraIdle(intent.zoom)
+        }
+    }
+
+    private fun loadInitialData() {
+        if (uiState.value.allCities.isNotEmpty()) return
+        viewModelScope.launch {
+            val cities = withContext(Dispatchers.IO) { parseCitiesFromAssets() }
+            setState { copy(allCities = cities) }
+            loadWeatherForCities(cities.filter { it.tier == 1 })
+        }
+    }
+
+    private fun onCameraIdle(zoom: Double) {
+        val maxTier = if (zoom <= ZOOM_TIER1_ONLY) 1 else 2
+        val cities = uiState.value.allCities.filter { it.tier <= maxTier }
+        loadWeatherForCities(cities)
+    }
+
+    private fun loadWeatherForCities(cities: List<CityInfo>) {
+        val cached = uiState.value.cityWeatherMap
+        val toLoad = cities.filter { !cached.containsKey(it.name) }
+        if (toLoad.isEmpty()) return
+
+        setState {
+            copy(
+                cityWeatherMap = cityWeatherMap + toLoad.associate {
+                    it.name to CityWeatherState(isLoading = true)
+                }
+            )
+        }
+
+        viewModelScope.launch {
+            val results = toLoad.map { city ->
+                async {
+                    runCatching {
+                        weatherUseCase.getCityPositionWeatherNow(city.name)
+                    }.getOrNull()?.let { vo ->
+                        city.name to CityWeatherState(
+                            temperature = vo.temperature,
+                            weatherCondition = vo.weatherCondition
+                        )
+                    } ?: (city.name to CityWeatherState())
+                }
+            }.awaitAll()
+
+            setState { copy(cityWeatherMap = cityWeatherMap + results.toMap()) }
+        }
+    }
+
+    private fun parseCitiesFromAssets(): List<CityInfo> {
+        return try {
+            val json = context.assets.open("json/cityCode.json").bufferedReader().use { it.readText() }
+            val array = JSONObject(json).getJSONArray("cityList")
+            buildList {
+                for (i in 0 until array.length()) {
+                    val obj = array.getJSONObject(i)
+                    val name = obj.getString("cityName")
+                    val tier = CITY_TIER_MAP[name] ?: continue
+                    add(
+                        CityInfo(
+                            name = name,
+                            lat = obj.getString("latitude").toDouble(),
+                            lon = obj.getString("longitude").toDouble(),
+                            tier = tier
+                        )
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://repository.map.naver.com/archive/maven") }
     }
 }
 rootProject.name = "Suncloud"


### PR DESCRIPTION
## 🔴 작업 내역
- Naver Maps SDK 3.23.2 연동: Maven 저장소 추가, NCP 인증 설정 (NCP_KEY_ID 메타데이터, NcpKeyClient 명시적 초기화)
- `cityCode.json` 기반 도시 좌표 런타임 파싱, Tier1(광역시 9개)/Tier2(주요 시 16개) zoom 분기 표시
- 커스텀 마커 UI — 날씨 아이콘 + 기온 Bitmap (`MarkerBitmapFactory`), 도시명 캡션
- 대한민국 지도 범위 락 (`extent`, `minZoom`) 으로 타 지역 이동 방지
- zoom 변화 시 마커 업데이트 누락 버그 수정 (탭 전환 후 확대, 축소 시 Tier2 마커 미제거)

## 🟡 추가한 라이브러리
- com.naver.maps:map-sdk:3.23.2

## 🟢 기타 전달 사항
- 날씨 데이터는 세션 내 도시명 key 기준으로 캐싱 처리되어 동일 화면 내 중복 API 호출 없음
- CLAUDE.md는 .gitignore 처리