### PR TITLE
[SC-1-9] feat : setting 탭 구현 및 온도 단위(°C/°F) 전탭 반영

### DIFF
--- a/data/src/main/java/com/knichu/data/datastore/WeatherDataStoreImpl.kt
+++ b/data/src/main/java/com/knichu/data/datastore/WeatherDataStoreImpl.kt
@@ -29,6 +29,14 @@ class WeatherDataStoreImpl @Inject constructor(
         else WeatherTempUnit.valueOf(unitStr.uppercase())
     }
 
+    override fun getTempUnitFlow(): Flow<WeatherTempUnit> {
+        return dataStore.data.map { pref ->
+            val unitStr = pref[TEMP_UNIT_KEY] ?: ""
+            if (unitStr.isEmpty()) WeatherTempUnit.CELSIUS
+            else WeatherTempUnit.valueOf(unitStr.uppercase())
+        }
+    }
+
     override suspend fun storeCity(cityName: String) {
         dataStore.updateData { pref ->
             pref.toMutablePreferences().also {

--- a/domain/src/main/java/com/knichu/domain/datastore/WeatherDataStore.kt
+++ b/domain/src/main/java/com/knichu/domain/datastore/WeatherDataStore.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.Flow
 interface WeatherDataStore {
     suspend fun storeUserTempUnit(unit: WeatherTempUnit)
     suspend fun getUserTempUnit(): WeatherTempUnit
+    fun getTempUnitFlow(): Flow<WeatherTempUnit>
     suspend fun storeCity(cityName: String)
     fun getCityList(): Flow<List<String>>
     suspend fun deleteCity(selectedCityList: MutableSet<String>)

--- a/domain/src/main/java/com/knichu/domain/usecase/DataStoreUseCase.kt
+++ b/domain/src/main/java/com/knichu/domain/usecase/DataStoreUseCase.kt
@@ -8,6 +8,8 @@ interface DataStoreUseCase {
 
     suspend fun getUserTempUnit(): WeatherTempUnit
 
+    fun getTempUnitFlow(): Flow<WeatherTempUnit>
+
     suspend fun storeCity(cityName: String)
 
     fun getCityList(): Flow<List<String>>

--- a/domain/src/main/java/com/knichu/domain/usecase/useCaseImpl/DataStoreUseCaseImpl.kt
+++ b/domain/src/main/java/com/knichu/domain/usecase/useCaseImpl/DataStoreUseCaseImpl.kt
@@ -19,6 +19,10 @@ class DataStoreUseCaseImpl @Inject constructor(
         return weatherDataStore.getUserTempUnit()
     }
 
+    override fun getTempUnitFlow(): Flow<WeatherTempUnit> {
+        return weatherDataStore.getTempUnitFlow()
+    }
+
     override suspend fun storeCity(cityName: String) {
         val cityList = weatherDataStore.getCityList().first()
         if (cityList.contains(cityName)) {

--- a/domain/src/main/java/com/knichu/domain/util/TemperatureParser.kt
+++ b/domain/src/main/java/com/knichu/domain/util/TemperatureParser.kt
@@ -1,0 +1,12 @@
+package com.knichu.domain.util
+
+import com.knichu.domain.constants.WeatherTempUnit
+import kotlin.math.roundToInt
+
+object TemperatureParser {
+    fun convert(celsius: String?, unit: WeatherTempUnit): String? {
+        if (unit != WeatherTempUnit.FAHRENHEIT) return celsius
+        val value = celsius?.toDoubleOrNull() ?: return celsius
+        return ((value * 9.0 / 5.0) + 32.0).roundToInt().toString()
+    }
+}

--- a/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastContract.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastContract.kt
@@ -1,5 +1,6 @@
 package com.knichu.forecast.ui.forecast
 
+import com.knichu.domain.constants.WeatherTempUnit
 import com.knichu.domain.vo.AirPollutionDataVO
 import com.knichu.domain.vo.SunriseSunsetVO
 import com.knichu.domain.vo.Weather24HourItemVO
@@ -10,6 +11,7 @@ import com.knichu.domain.vo.WeatherOtherInfoVO
 import com.knichu.domain.vo.WeatherWeeklyItemVO
 
 data class ForecastUiState(
+    val tempUnit: WeatherTempUnit = WeatherTempUnit.CELSIUS,
     val isLoading: Boolean = false,
     val isDrawerOpen: Boolean = false,
     val selectedCity: String? = null,           // null = 현재 위치

--- a/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastScreen.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastScreen.kt
@@ -75,6 +75,8 @@ import androidx.core.content.ContextCompat
 import com.knichu.common_ui.R
 import com.knichu.common_ui.enums.WeatherIcon
 import com.knichu.common_ui.enums.WindDirectionIcon
+import com.knichu.domain.constants.WeatherTempUnit
+import com.knichu.domain.util.TemperatureParser
 import com.knichu.domain.vo.AirPollutionDataVO
 import com.knichu.domain.vo.SunriseSunsetVO
 import com.knichu.domain.vo.Weather24HourItemVO
@@ -312,10 +314,10 @@ fun ForecastScreen(
                     ) {
                         ForecastHeroSection(state = state)
                         if (state.weather24Hour.isNotEmpty()) {
-                            Weather24HourCard(items = state.weather24Hour)
+                            Weather24HourCard(items = state.weather24Hour, tempUnit = state.tempUnit)
                         }
                         if (state.weatherWeekly.isNotEmpty()) {
-                            WeatherWeeklyCard(items = state.weatherWeekly)
+                            WeatherWeeklyCard(items = state.weatherWeekly, tempUnit = state.tempUnit)
                         }
                         state.airPollution?.let { AirPollutionCard(data = it) }
                         state.sunriseSunset?.let { SunriseSunsetCard(data = it) }
@@ -356,7 +358,7 @@ private fun ForecastHeroSection(state: ForecastUiState) {
                 color = Color.Black
             )
             Text(
-                text = "${state.weatherNow?.temperature ?: "-"}°",
+                text = "${TemperatureParser.convert(state.weatherNow?.temperature, state.tempUnit) ?: "-"}°",
                 fontSize = 34.sp,
                 color = Color.Gray
             )
@@ -388,7 +390,7 @@ private fun WeatherCard(
 }
 
 @Composable
-private fun Weather24HourCard(items: List<Weather24HourItemVO>) {
+private fun Weather24HourCard(items: List<Weather24HourItemVO>, tempUnit: WeatherTempUnit) {
     WeatherCard {
         Row(
             modifier = Modifier
@@ -405,7 +407,7 @@ private fun Weather24HourCard(items: List<Weather24HourItemVO>) {
                     Spacer(modifier = Modifier.height(6.dp))
                     WeatherIconImage(weatherCondition = item.weatherCondition, size = 32.dp)
                     Spacer(modifier = Modifier.height(6.dp))
-                    Text("${item.temperature ?: "-"}°", fontSize = 18.sp, fontWeight = FontWeight.Medium)
+                    Text("${TemperatureParser.convert(item.temperature, tempUnit) ?: "-"}°", fontSize = 18.sp, fontWeight = FontWeight.Medium)
                     Spacer(modifier = Modifier.height(4.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Image(
@@ -422,7 +424,7 @@ private fun Weather24HourCard(items: List<Weather24HourItemVO>) {
 }
 
 @Composable
-private fun WeatherWeeklyCard(items: List<WeatherWeeklyItemVO>) {
+private fun WeatherWeeklyCard(items: List<WeatherWeeklyItemVO>, tempUnit: WeatherTempUnit) {
     WeatherCard {
         Column(modifier = Modifier.padding(vertical = 4.dp)) {
             items.forEachIndexed { index, item ->
@@ -455,13 +457,13 @@ private fun WeatherWeeklyCard(items: List<WeatherWeeklyItemVO>) {
                     WeatherIconImage(weatherCondition = item.weatherConditionPM, size = 24.dp)
                     Spacer(modifier = Modifier.width(16.dp))
                     Text(
-                        "${item.minTemperature ?: "-"}°",
+                        "${TemperatureParser.convert(item.minTemperature, tempUnit) ?: "-"}°",
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.width(36.dp)
                     )
                     Text(
-                        "${item.maxTemperature ?: "-"}°",
+                        "${TemperatureParser.convert(item.maxTemperature, tempUnit) ?: "-"}°",
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.width(36.dp)
@@ -671,7 +673,7 @@ private fun ForecastDrawerContent(
             Text("📍 현재 위치", fontSize = 16.sp)
             state.currentPositionCity?.let {
                 Spacer(modifier = Modifier.weight(1f))
-                Text("${it.temperature}°", fontSize = 14.sp)
+                Text("${TemperatureParser.convert(it.temperature, state.tempUnit) ?: "-"}°", fontSize = 14.sp)
             }
         }
 
@@ -691,7 +693,7 @@ private fun ForecastDrawerContent(
                     Spacer(modifier = Modifier.weight(1f))
                     WeatherIconImage(weatherCondition = item.weatherCondition, size = 20.dp)
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text("${item.temperature ?: "-"}°", fontSize = 14.sp)
+                    Text("${TemperatureParser.convert(item.temperature, state.tempUnit) ?: "-"}°", fontSize = 14.sp)
                 }
                 Divider()
             }
@@ -746,7 +748,7 @@ private fun HeroPreview() {
 private fun Weather24HourPreview() {
     MaterialTheme {
         Box(modifier = Modifier.background(BgColor)) {
-            Weather24HourCard(items = previewState.weather24Hour)
+            Weather24HourCard(items = previewState.weather24Hour, tempUnit = WeatherTempUnit.CELSIUS)
         }
     }
 }
@@ -756,7 +758,7 @@ private fun Weather24HourPreview() {
 private fun WeatherWeeklyPreview() {
     MaterialTheme {
         Box(modifier = Modifier.background(BgColor)) {
-            WeatherWeeklyCard(items = previewState.weatherWeekly)
+            WeatherWeeklyCard(items = previewState.weatherWeekly, tempUnit = WeatherTempUnit.CELSIUS)
         }
     }
 }

--- a/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastViewModel.kt
+++ b/forecast/src/main/java/com/knichu/forecast/ui/forecast/ForecastViewModel.kt
@@ -23,6 +23,7 @@ class ForecastViewModel @Inject constructor(
 
     init {
         observeCityList()
+        observeTempUnit()
     }
 
     override fun handleIntent(intent: ForecastUiIntent) {
@@ -156,6 +157,14 @@ class ForecastViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { weatherUseCase.getCurrentPositionWeatherNow(lon, lat) }
                 .onSuccess { result -> setState { copy(currentPositionCity = result) } }
+        }
+    }
+
+    private fun observeTempUnit() {
+        viewModelScope.launch {
+            dataStoreUseCase.getTempUnitFlow().collect { unit ->
+                setState { copy(tempUnit = unit) }
+            }
         }
     }
 

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/MarkerBitmapFactory.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/MarkerBitmapFactory.kt
@@ -11,12 +11,14 @@ import android.graphics.Typeface
 import android.util.TypedValue
 import androidx.appcompat.content.res.AppCompatResources
 import com.knichu.common_ui.enums.WeatherIcon
+import com.knichu.domain.constants.WeatherTempUnit
+import com.knichu.domain.util.TemperatureParser
 import com.naver.maps.map.overlay.OverlayImage
 
 object MarkerBitmapFactory {
 
-    fun create(context: Context, weatherCondition: String?, temperature: String?): OverlayImage =
-        OverlayImage.fromBitmap(createBitmap(context, weatherCondition, temperature))
+    fun create(context: Context, weatherCondition: String?, temperature: String?, unit: WeatherTempUnit = WeatherTempUnit.CELSIUS): OverlayImage =
+        OverlayImage.fromBitmap(createBitmap(context, weatherCondition, TemperatureParser.convert(temperature, unit)))
 
     private fun createBitmap(context: Context, weatherCondition: String?, temperature: String?): Bitmap {
         val dm = context.resources.displayMetrics

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideContract.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideContract.kt
@@ -1,8 +1,10 @@
 package com.knichu.nationwide.ui
 
+import com.knichu.domain.constants.WeatherTempUnit
 import com.knichu.nationwide.model.CityInfo
 
 data class NationwideUiState(
+    val tempUnit: WeatherTempUnit = WeatherTempUnit.CELSIUS,
     val allCities: List<CityInfo> = emptyList(),
     val cityWeatherMap: Map<String, CityWeatherState> = emptyMap(),
     val error: String? = null

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideScreen.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideScreen.kt
@@ -78,9 +78,9 @@ private fun NationwideMapView(
         modifier = modifier
     )
 
-    // zoom 변화 또는 날씨 데이터 변화 시 마커 업데이트
+    // zoom, 날씨 데이터, 온도 단위 변화 시 마커 업데이트
     val map = naverMapRef.value
-    LaunchedEffect(map, uiState.cityWeatherMap, uiState.allCities, currentZoom.value) {
+    LaunchedEffect(map, uiState.cityWeatherMap, uiState.allCities, currentZoom.value, uiState.tempUnit) {
         if (map == null) return@LaunchedEffect
         updateMarkers(context, map, uiState, markersRef)
     }
@@ -132,7 +132,7 @@ private fun updateMarkers(
         if (weather.isLoading || weather.temperature == null) return@forEach
 
         val cityInfo = uiState.allCities.find { it.name == cityName } ?: return@forEach
-        val icon = MarkerBitmapFactory.create(context, weather.weatherCondition, weather.temperature)
+        val icon = MarkerBitmapFactory.create(context, weather.weatherCondition, weather.temperature, uiState.tempUnit)
 
         val existing = markers[cityName]
         if (existing != null) {

--- a/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideViewModel.kt
+++ b/nationwide/src/main/java/com/knichu/nationwide/ui/NationwideViewModel.kt
@@ -3,6 +3,7 @@ package com.knichu.nationwide.ui
 import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.knichu.common.base.BaseMviViewModel
+import com.knichu.domain.useCase.DataStoreUseCase
 import com.knichu.domain.useCase.WeatherUseCase
 import com.knichu.nationwide.model.CITY_TIER_MAP
 import com.knichu.nationwide.model.CityInfo
@@ -20,15 +21,28 @@ import javax.inject.Inject
 @HiltViewModel
 class NationwideViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val weatherUseCase: WeatherUseCase
+    private val weatherUseCase: WeatherUseCase,
+    private val dataStoreUseCase: DataStoreUseCase
 ) : BaseMviViewModel<NationwideUiIntent, NationwideUiState, NationwideUiEffect>() {
 
     override fun initialState() = NationwideUiState()
+
+    init {
+        observeTempUnit()
+    }
 
     override fun handleIntent(intent: NationwideUiIntent) {
         when (intent) {
             is NationwideUiIntent.LoadInitialData -> loadInitialData()
             is NationwideUiIntent.OnCameraIdle -> onCameraIdle(intent.zoom)
+        }
+    }
+
+    private fun observeTempUnit() {
+        viewModelScope.launch {
+            dataStoreUseCase.getTempUnitFlow().collect { unit ->
+                setState { copy(tempUnit = unit) }
+            }
         }
     }
 

--- a/setting/src/main/java/com/knichu/setting/ui/SettingContract.kt
+++ b/setting/src/main/java/com/knichu/setting/ui/SettingContract.kt
@@ -1,9 +1,13 @@
 package com.knichu.setting.ui
 
+import com.knichu.domain.constants.WeatherTempUnit
+
 data class SettingUiState(
-    val dummy: Unit = Unit
+    val tempUnit: WeatherTempUnit = WeatherTempUnit.CELSIUS
 )
 
-sealed class SettingUiIntent
+sealed class SettingUiIntent {
+    data class OnTempUnitChanged(val unit: WeatherTempUnit) : SettingUiIntent()
+}
 
 sealed class SettingUiEffect

--- a/setting/src/main/java/com/knichu/setting/ui/SettingHostFragment.kt
+++ b/setting/src/main/java/com/knichu/setting/ui/SettingHostFragment.kt
@@ -23,7 +23,7 @@ class SettingHostFragment : Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 MaterialTheme {
-                    SettingScreen()
+                    SettingScreen(viewModel = viewModel)
                 }
             }
         }

--- a/setting/src/main/java/com/knichu/setting/ui/SettingScreen.kt
+++ b/setting/src/main/java/com/knichu/setting/ui/SettingScreen.kt
@@ -1,29 +1,108 @@
 package com.knichu.setting.ui
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.knichu.domain.constants.WeatherTempUnit
 
 @Composable
-fun SettingScreen() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+fun SettingScreen(viewModel: SettingViewModel) {
+    val uiState by viewModel.uiState.collectAsState()
+    SettingContent(
+        tempUnit = uiState.tempUnit,
+        onTempUnitChanged = { viewModel.handleIntent(SettingUiIntent.OnTempUnitChanged(it)) }
+    )
+}
+
+@Composable
+private fun SettingContent(
+    tempUnit: WeatherTempUnit,
+    onTempUnitChanged: (WeatherTempUnit) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF5F5F5))
     ) {
-        Text(text = "출시 준비중입니다", fontSize = 34.sp)
+        Text(
+            text = "설정",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 24.dp)
+        )
+
+        SectionHeader("온도 단위")
+
+        TempUnitRow(
+            label = "섭씨 (°C)",
+            selected = tempUnit == WeatherTempUnit.CELSIUS,
+            onClick = { onTempUnitChanged(WeatherTempUnit.CELSIUS) }
+        )
+        Divider(modifier = Modifier.padding(start = 20.dp))
+        TempUnitRow(
+            label = "화씨 (°F)",
+            selected = tempUnit == WeatherTempUnit.FAHRENHEIT,
+            onClick = { onTempUnitChanged(WeatherTempUnit.FAHRENHEIT) }
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        fontSize = 13.sp,
+        color = Color(0xFF888888),
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+    )
+}
+
+@Composable
+private fun TempUnitRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.White)
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Text(
+            text = label,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(start = 4.dp)
+        )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun SettingScreenPreview() {
+private fun SettingContentPreview() {
     MaterialTheme {
-        SettingScreen()
+        SettingContent(
+            tempUnit = WeatherTempUnit.CELSIUS,
+            onTempUnitChanged = {}
+        )
     }
 }

--- a/setting/src/main/java/com/knichu/setting/ui/SettingViewModel.kt
+++ b/setting/src/main/java/com/knichu/setting/ui/SettingViewModel.kt
@@ -1,8 +1,11 @@
 package com.knichu.setting.ui
 
+import androidx.lifecycle.viewModelScope
 import com.knichu.common.base.BaseMviViewModel
+import com.knichu.domain.constants.WeatherTempUnit
 import com.knichu.domain.useCase.DataStoreUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -12,5 +15,27 @@ class SettingViewModel @Inject constructor(
 
     override fun initialState() = SettingUiState()
 
-    override fun handleIntent(intent: SettingUiIntent) {}
+    init {
+        loadTempUnit()
+    }
+
+    override fun handleIntent(intent: SettingUiIntent) {
+        when (intent) {
+            is SettingUiIntent.OnTempUnitChanged -> saveTempUnit(intent.unit)
+        }
+    }
+
+    private fun loadTempUnit() {
+        viewModelScope.launch {
+            val unit = dataStoreUseCase.getUserTempUnit()
+            setState { copy(tempUnit = if (unit == WeatherTempUnit.NONE) WeatherTempUnit.CELSIUS else unit) }
+        }
+    }
+
+    private fun saveTempUnit(unit: WeatherTempUnit) {
+        setState { copy(tempUnit = unit) }
+        viewModelScope.launch {
+            dataStoreUseCase.storeUserTempUnit(unit)
+        }
+    }
 }


### PR DESCRIPTION
## 🔴 작업 내역
- setting 탭 UI 구현: 섭씨(°C) / 화씨(°F) 라디오 버튼, DataStore 저장/로드
- `TemperatureParser` 신설 (domain/util): 섭씨 → 화씨 변환 로직 도메인 레이어에 집중
- `getTempUnitFlow(): Flow<WeatherTempUnit>` 추가 — DataStore → UseCase 인터페이스 전 계층 확장
- 날씨탭: 현재 기온, 24시간 예보, 주간 예보, 드로어 도시 목록 온도 모두 단위 변환 적용
- 전국탭: ViewModel에서 tempUnit flow 구독 → LaunchedEffect 키 추가 → 마커 온도 즉시 갱신

## 🟡 추가한 라이브러리
- 없음

## 🟢 기타 전달 사항
- 단위 변환은 UI 렌더링 시점에만 수행, VO/State에는 원본 °C 값 유지
- 설정 변경 즉시 두 탭에 실시간 반영 (Flow 기반)