### PR TITLE
[SC-1-10] refactor : Hilt DI 모듈 app으로 이동 및 모듈 의존성 정리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,9 +118,6 @@ dependencies {
 
     // module
     api(project(":gateway"))
-    api(project(":forecast"))
-    api(project(":nationwide"))
-    api(project(":setting"))
     api(project(":data"))
 
     // Naver Maps (Application 클래스에서 SDK 초기화용)

--- a/app/src/main/java/com/knichu/suncloud/di/DataStoreModule.kt
+++ b/app/src/main/java/com/knichu/suncloud/di/DataStoreModule.kt
@@ -1,4 +1,4 @@
-package com.knichu.gateway.di
+package com.knichu.suncloud.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore

--- a/app/src/main/java/com/knichu/suncloud/di/NetworkModule.kt
+++ b/app/src/main/java/com/knichu/suncloud/di/NetworkModule.kt
@@ -1,4 +1,4 @@
-package com.knichu.gateway.di
+package com.knichu.suncloud.di
 
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/knichu/suncloud/di/Qualifiers.kt
+++ b/app/src/main/java/com/knichu/suncloud/di/Qualifiers.kt
@@ -1,4 +1,4 @@
-package com.knichu.gateway.di
+package com.knichu.suncloud.di
 
 import javax.inject.Qualifier
 

--- a/app/src/main/java/com/knichu/suncloud/di/RepositoryModule.kt
+++ b/app/src/main/java/com/knichu/suncloud/di/RepositoryModule.kt
@@ -1,4 +1,4 @@
-package com.knichu.gateway.di
+package com.knichu.suncloud.di
 
 import com.knichu.data.repository.AirPollutionRepositoryImpl
 import com.knichu.data.repository.CityLocationRepositoryImpl

--- a/app/src/main/java/com/knichu/suncloud/di/RetrofitServiceModule.kt
+++ b/app/src/main/java/com/knichu/suncloud/di/RetrofitServiceModule.kt
@@ -1,4 +1,4 @@
-package com.knichu.gateway.di
+package com.knichu.suncloud.di
 
 import android.app.Application
 import android.content.Context

--- a/app/src/main/java/com/knichu/suncloud/di/UseCaseModule.kt
+++ b/app/src/main/java/com/knichu/suncloud/di/UseCaseModule.kt
@@ -1,4 +1,4 @@
-package com.knichu.gateway.di
+package com.knichu.suncloud.di
 
 import com.knichu.domain.useCase.AirPollutionUseCase
 import com.knichu.domain.useCase.DataStoreUseCase

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -79,6 +79,8 @@ dependencies {
     ksp("com.google.dagger:hilt-android-compiler:2.50")
     implementation("com.google.dagger:hilt-android:2.50")
 
+    api("androidx.fragment:fragment-ktx:1.6.1")
+
     // Coroutines
     api("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     api("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -84,17 +84,10 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-    api("androidx.fragment:fragment-ktx:1.6.1")
-    api("androidx.navigation:navigation-fragment-ktx:2.5.3")
-    api("androidx.navigation:navigation-ui-ktx:2.5.3")
-
     ksp("com.google.dagger:hilt-android-compiler:2.50")
     implementation("com.google.dagger:hilt-android:2.50")
 
     // Coroutines
     api("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
-
-    // DataStore
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
 }
 

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -78,5 +78,9 @@ dependencies {
 
     ksp("com.google.dagger:hilt-android-compiler:2.50")
     implementation("com.google.dagger:hilt-android:2.50")
+
+    // Navigation (GatewayActivity - NavHostFragment, setupWithNavController)
+    implementation("androidx.navigation:navigation-fragment-ktx:2.5.3")
+    implementation("androidx.navigation:navigation-ui-ktx:2.5.3")
 }
 

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
     api(project(":forecast"))
     api(project(":nationwide"))
     api(project(":setting"))
-    api(project(":data"))
 
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.core:core-splashscreen:1.0.1")
@@ -79,17 +78,5 @@ dependencies {
 
     ksp("com.google.dagger:hilt-android-compiler:2.50")
     implementation("com.google.dagger:hilt-android:2.50")
-
-    // Network
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
-    // define a BOM and its version
-    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.11.0"))
-    // define any required OkHttp artifacts without version
-    implementation("com.squareup.okhttp3:okhttp")
-    implementation("com.squareup.okhttp3:logging-interceptor")
-
-    // DataStore
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
 }
 


### PR DESCRIPTION
## 🔴 작업 내역

- Hilt DI 모듈(`NetworkModule`, `DataStoreModule`, `RepositoryModule`, `UseCaseModule`, `RetrofitServiceModule`, `Qualifiers`) 을 `gateway/di/` → `app/di/` 로 이동
  - 패키지 `com.knichu.gateway.di` → `com.knichu.suncloud.di` 로 변경
  - `gateway/build.gradle.kts` 에서 DI에만 쓰이던 Retrofit, OkHttp, DataStore, `:data` 의존성 제거
- 모듈 의존성 정리
  - `domain/build.gradle.kts` : UI 레이어 의존성(`fragment-ktx`, `navigation-fragment-ktx`, `navigation-ui-ktx`, `datastore`) 제거
  - `common/build.gradle.kts` : `fragment-ktx` 추가 (feature HostFragment 용)
  - `gateway/build.gradle.kts` : `navigation-fragment-ktx`, `navigation-ui-ktx` 추가 (GatewayActivity 용)
  - `app/build.gradle.kts` : gateway가 이미 노출하는 중복 모듈 선언(`:forecast`, `:nationwide`, `:setting`) 제거

## 🟡 추가한 라이브러리

없음 (기존 의존성 위치 정리만 진행)

## 🟢 기타 전달 사항

- DI는 composition root인 `app` 모듈에 두는 것이 Clean Architecture 관점에서 적합하여 이동
- `domain` 모듈에 있던 `fragment`, `navigation` 의존성은 도메인 레이어가 UI 레이어에 의존하는 구조였으므로 실제 사용처(`common`, `gateway`)로 분리